### PR TITLE
Feature/Refactor: Unified API Standards, Global Exception Handling, and Auth Optimization

### DIFF
--- a/Phase1-Group-Projects/6-InsightFlow/backend/pom.xml
+++ b/Phase1-Group-Projects/6-InsightFlow/backend/pom.xml
@@ -49,6 +49,13 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-cache</artifactId>
     </dependency>
+    <!-- Source: https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-aop -->
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-aop</artifactId>
+        <version>4.0.0-M2</version>
+        <scope>compile</scope>
+    </dependency>
 
     <!-- Database & Tools -->
     <dependency>

--- a/Phase1-Group-Projects/6-InsightFlow/backend/src/main/java/com/insightflow/aspect/LoggingAspect.java
+++ b/Phase1-Group-Projects/6-InsightFlow/backend/src/main/java/com/insightflow/aspect/LoggingAspect.java
@@ -1,0 +1,54 @@
+package com.insightflow.aspect;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+public class LoggingAspect {
+
+    /** Monitors all controller methods — logs entry, exit, and execution time. */
+    @Around("execution(* com.insightflow.controller..*(..))")
+    public Object monitorController(ProceedingJoinPoint joinPoint) throws Throwable {
+        String cls = joinPoint.getTarget().getClass().getSimpleName();
+        String method = joinPoint.getSignature().getName();
+        long start = System.currentTimeMillis();
+
+        log.info("[REQUEST]  {}.{}()", cls, method);
+        try {
+            Object result = joinPoint.proceed();
+            log.info("[RESPONSE] {}.{}() completed in {}ms", cls, method, elapsed(start));
+            return result;
+        } catch (Throwable ex) {
+            log.error("[FAILED]   {}.{}() threw {} after {}ms — {}",
+                    cls, method, ex.getClass().getSimpleName(), elapsed(start), ex.getMessage());
+            throw ex;
+        }
+    }
+
+    /** Monitors all service methods — logs execution time at DEBUG level. */
+    @Around("execution(* com.insightflow.service..*(..))")
+    public Object monitorService(ProceedingJoinPoint joinPoint) throws Throwable {
+        String cls = joinPoint.getTarget().getClass().getSimpleName();
+        String method = joinPoint.getSignature().getName();
+        long start = System.currentTimeMillis();
+
+        try {
+            Object result = joinPoint.proceed();
+            log.debug("[SERVICE]  {}.{}() — {}ms", cls, method, elapsed(start));
+            return result;
+        } catch (Throwable ex) {
+            log.error("[SERVICE]  {}.{}() threw {} — {}ms",
+                    cls, method, ex.getClass().getSimpleName(), elapsed(start));
+            throw ex;
+        }
+    }
+
+    private long elapsed(long startMs) {
+        return System.currentTimeMillis() - startMs;
+    }
+}

--- a/Phase1-Group-Projects/6-InsightFlow/backend/src/main/java/com/insightflow/config/JwtAuthFilter.java
+++ b/Phase1-Group-Projects/6-InsightFlow/backend/src/main/java/com/insightflow/config/JwtAuthFilter.java
@@ -1,6 +1,6 @@
 package com.insightflow.config;
 
-import com.insightflow.repository.UserRepository;
+import com.insightflow.model.UserPrincipal;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -17,7 +17,6 @@ import java.util.List;
 @Component @RequiredArgsConstructor
 public class JwtAuthFilter extends OncePerRequestFilter {
     private final JwtService jwtService;
-    private final UserRepository userRepository;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
@@ -28,12 +27,13 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         }
         String token = authHeader.substring(7);
         if (jwtService.isTokenValid(token)) {
-            String email = jwtService.extractEmail(token);
-            userRepository.findByEmail(email).ifPresent(user -> {
-                var auth = new UsernamePasswordAuthenticationToken(user, null,
-                        List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name())));
-                SecurityContextHolder.getContext().setAuthentication(auth);
-            });
+            String email  = jwtService.extractEmail(token);
+            String role   = jwtService.extractRole(token);
+            Long   userId = jwtService.extractUserId(token);
+            var principal = new UserPrincipal(userId, email, role);
+            var auth = new UsernamePasswordAuthenticationToken(
+                    principal, null, List.of(new SimpleGrantedAuthority("ROLE_" + role)));
+            SecurityContextHolder.getContext().setAuthentication(auth);
         }
         filterChain.doFilter(request, response);
     }

--- a/Phase1-Group-Projects/6-InsightFlow/backend/src/main/java/com/insightflow/config/JwtService.java
+++ b/Phase1-Group-Projects/6-InsightFlow/backend/src/main/java/com/insightflow/config/JwtService.java
@@ -19,10 +19,11 @@ public class JwtService {
         return Keys.hmacShaKeyFor(keyBytes);
     }
 
-    public String generateToken(String email, String role) {
+    public String generateToken(Long userId, String email, String role) {
         return Jwts.builder()
                 .subject(email)
                 .claim("role", role)
+                .claim("userId", userId)
                 .issuedAt(new Date())
                 .expiration(new Date(System.currentTimeMillis() + expiration))
                 .signWith(getSigningKey())
@@ -30,23 +31,31 @@ public class JwtService {
     }
 
     public String extractEmail(String token) {
-        return Jwts.parser()
-                .verifyWith((javax.crypto.SecretKey) getSigningKey()) // ✅ new API
-                .build()
-                .parseSignedClaims(token) // ✅ replaces parseClaimsJws()
-                .getPayload()
-                .getSubject();
+        return getClaims(token).getSubject();
+    }
+
+    public String extractRole(String token) {
+        return getClaims(token).get("role", String.class);
+    }
+
+    public Long extractUserId(String token) {
+        return getClaims(token).get("userId", Long.class);
     }
 
     public boolean isTokenValid(String token) {
         try {
-            Jwts.parser()
-                    .verifyWith((javax.crypto.SecretKey) getSigningKey()) // ✅ new API
-                    .build()
-                    .parseSignedClaims(token); // ✅ replaces parseClaimsJws()
+            getClaims(token);
             return true;
         } catch (JwtException e) {
             return false;
         }
+    }
+
+    private io.jsonwebtoken.Claims getClaims(String token) {
+        return Jwts.parser()
+                .verifyWith((javax.crypto.SecretKey) getSigningKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
     }
 }

--- a/Phase1-Group-Projects/6-InsightFlow/backend/src/main/java/com/insightflow/controller/AuthController.java
+++ b/Phase1-Group-Projects/6-InsightFlow/backend/src/main/java/com/insightflow/controller/AuthController.java
@@ -1,23 +1,34 @@
 package com.insightflow.controller;
 
-import org.springframework.web.bind.annotation.*;
-import com.insightflow.dto.*;
+import com.insightflow.dto.ApiResponse;
+import com.insightflow.dto.AuthRequest;
+import com.insightflow.dto.AuthResponse;
+import com.insightflow.dto.RegisterRequest;
+import com.insightflow.model.User;
 import com.insightflow.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController @RequestMapping("/api/auth") @RequiredArgsConstructor
 public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/register")
-    public ResponseEntity<AuthResponse> register(@Valid @RequestBody RegisterRequest request) {
-        return ResponseEntity.ok(authService.register(request));
+    public ResponseEntity<ApiResponse<AuthResponse>> register(@Valid @RequestBody RegisterRequest request) {
+        return ResponseEntity.ok(ApiResponse.success("Registration successful", authService.register(request)));
     }
 
     @PostMapping("/login")
-    public ResponseEntity<AuthResponse> login(@Valid @RequestBody AuthRequest request) {
-        return ResponseEntity.ok(authService.login(request));
+    public ResponseEntity<ApiResponse<AuthResponse>> login(@Valid @RequestBody AuthRequest request) {
+        return ResponseEntity.ok(ApiResponse.success("Login successful", authService.login(request)));
+    }
+
+    @GetMapping("/users")
+    public ResponseEntity<ApiResponse<List<User>>> getAllUsers() {
+        return ResponseEntity.ok(ApiResponse.success(authService.getAllUsers()));
     }
 }

--- a/Phase1-Group-Projects/6-InsightFlow/backend/src/main/java/com/insightflow/controller/DataSourceController.java
+++ b/Phase1-Group-Projects/6-InsightFlow/backend/src/main/java/com/insightflow/controller/DataSourceController.java
@@ -1,13 +1,16 @@
 package com.insightflow.controller;
 
-import com.insightflow.dto.*;
-import org.springframework.web.bind.annotation.*;
-import com.insightflow.model.User;
+import com.insightflow.dto.ApiResponse;
+import com.insightflow.dto.DataSourceRequest;
+import com.insightflow.dto.DataSourceResponse;
+import com.insightflow.model.UserPrincipal;
 import com.insightflow.service.DataSourceService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
 import java.util.List;
 
 @RestController @RequestMapping("/api/datasources") @RequiredArgsConstructor
@@ -15,15 +18,14 @@ public class DataSourceController {
     private final DataSourceService dataSourceService;
 
     @GetMapping
-    public ResponseEntity<List<DataSourceResponse>> getAll() {
-        return ResponseEntity.ok(dataSourceService.getAll());
+    public ResponseEntity<ApiResponse<List<DataSourceResponse>>> getAll() {
+        return ResponseEntity.ok(ApiResponse.success(dataSourceService.getAll()));
     }
 
     @PostMapping
-    public ResponseEntity<DataSourceResponse> create(
+    public ResponseEntity<ApiResponse<DataSourceResponse>> create(
             @Valid @RequestBody DataSourceRequest request,
-            @AuthenticationPrincipal User user) {
-        return ResponseEntity.ok(dataSourceService.create(request, user));
+            @AuthenticationPrincipal UserPrincipal principal) {
+        return ResponseEntity.ok(ApiResponse.success("Data source created", dataSourceService.create(request, principal)));
     }
-
 }

--- a/Phase1-Group-Projects/6-InsightFlow/backend/src/main/java/com/insightflow/controller/PipelineController.java
+++ b/Phase1-Group-Projects/6-InsightFlow/backend/src/main/java/com/insightflow/controller/PipelineController.java
@@ -1,13 +1,16 @@
 package com.insightflow.controller;
 
-import com.insightflow.dto.*;
-import org.springframework.web.bind.annotation.*;
-import com.insightflow.model.User;
+import com.insightflow.dto.ApiResponse;
+import com.insightflow.dto.PipelineRequest;
+import com.insightflow.dto.PipelineResponse;
+import com.insightflow.model.UserPrincipal;
 import com.insightflow.service.PipelineService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
 import java.util.List;
 
 @RestController @RequestMapping("/api/pipelines") @RequiredArgsConstructor
@@ -15,20 +18,20 @@ public class PipelineController {
     private final PipelineService pipelineService;
 
     @GetMapping
-    public ResponseEntity<List<PipelineResponse>> getAll() {
-        return ResponseEntity.ok(pipelineService.getAll());
+    public ResponseEntity<ApiResponse<List<PipelineResponse>>> getAll() {
+        return ResponseEntity.ok(ApiResponse.success(pipelineService.getAll()));
     }
 
     @PostMapping
-    public ResponseEntity<PipelineResponse> create(
+    public ResponseEntity<ApiResponse<PipelineResponse>> create(
             @Valid @RequestBody PipelineRequest request,
-            @AuthenticationPrincipal User user) {
-        return ResponseEntity.ok(pipelineService.create(request, user));
+            @AuthenticationPrincipal UserPrincipal principal) {
+        return ResponseEntity.ok(ApiResponse.success("Pipeline created", pipelineService.create(request, principal)));
     }
 
     @PostMapping("/{id}/run")
-    public ResponseEntity<PipelineResponse> run(@PathVariable Long id) {
-        return ResponseEntity.ok(pipelineService.runPipeline(id));
+    public ResponseEntity<ApiResponse<PipelineResponse>> run(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.success("Pipeline started", pipelineService.runPipeline(id)));
     }
 
     // TODO: Add GET /{id}/reports endpoint

--- a/Phase1-Group-Projects/6-InsightFlow/backend/src/main/java/com/insightflow/dto/ApiResponse.java
+++ b/Phase1-Group-Projects/6-InsightFlow/backend/src/main/java/com/insightflow/dto/ApiResponse.java
@@ -1,0 +1,24 @@
+package com.insightflow.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ApiResponse<T> {
+    private final String status;
+    private final String message;
+    private final T data;
+
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return ApiResponse.<T>builder().status("success").message(message).data(data).build();
+    }
+
+    public static <T> ApiResponse<T> success(T data) {
+        return ApiResponse.<T>builder().status("success").message("OK").data(data).build();
+    }
+
+    public static <T> ApiResponse<T> error(String message) {
+        return ApiResponse.<T>builder().status("error").message(message).data(null).build();
+    }
+}

--- a/Phase1-Group-Projects/6-InsightFlow/backend/src/main/java/com/insightflow/exception/AppException.java
+++ b/Phase1-Group-Projects/6-InsightFlow/backend/src/main/java/com/insightflow/exception/AppException.java
@@ -1,0 +1,31 @@
+package com.insightflow.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class AppException extends RuntimeException {
+
+    private final HttpStatus status;
+
+    public AppException(String message, HttpStatus status) {
+        super(message);
+        this.status = status;
+    }
+
+    public static AppException notFound(String message) {
+        return new AppException(message, HttpStatus.NOT_FOUND);
+    }
+
+    public static AppException badRequest(String message) {
+        return new AppException(message, HttpStatus.BAD_REQUEST);
+    }
+
+    public static AppException conflict(String message) {
+        return new AppException(message, HttpStatus.CONFLICT);
+    }
+
+    public static AppException unauthorized(String message) {
+        return new AppException(message, HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/Phase1-Group-Projects/6-InsightFlow/backend/src/main/java/com/insightflow/exception/GlobalExceptionHandler.java
+++ b/Phase1-Group-Projects/6-InsightFlow/backend/src/main/java/com/insightflow/exception/GlobalExceptionHandler.java
@@ -1,0 +1,42 @@
+package com.insightflow.exception;
+
+import com.insightflow.dto.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(AppException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAppException(AppException ex) {
+        log.warn("AppException [{}]: {}", ex.getStatus(), ex.getMessage());
+        return ResponseEntity.status(ex.getStatus()).body(ApiResponse.error(ex.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidation(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult().getFieldErrors().stream()
+                .map(e -> e.getField() + ": " + e.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+        log.warn("Validation failed: {}", message);
+        return ResponseEntity.badRequest().body(ApiResponse.error(message));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<Void>> handleIllegalArgument(IllegalArgumentException ex) {
+        log.warn("Bad request: {}", ex.getMessage());
+        return ResponseEntity.badRequest().body(ApiResponse.error(ex.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleGeneric(Exception ex) {
+        log.error("Unexpected error", ex);
+        return ResponseEntity.internalServerError().body(ApiResponse.error("An unexpected error occurred"));
+    }
+}

--- a/Phase1-Group-Projects/6-InsightFlow/backend/src/main/java/com/insightflow/model/UserPrincipal.java
+++ b/Phase1-Group-Projects/6-InsightFlow/backend/src/main/java/com/insightflow/model/UserPrincipal.java
@@ -1,0 +1,7 @@
+package com.insightflow.model;
+
+/**
+ * Lightweight security principal built from JWT claims — no DB hit required.
+ * Set as the principal in SecurityContextHolder on every authenticated request.
+ */
+public record UserPrincipal(Long id, String email, String role) {}

--- a/Phase1-Group-Projects/6-InsightFlow/backend/src/main/java/com/insightflow/service/AuthService.java
+++ b/Phase1-Group-Projects/6-InsightFlow/backend/src/main/java/com/insightflow/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.insightflow.service;
 
+import com.insightflow.exception.AppException;
 import com.insightflow.config.JwtService;
 import com.insightflow.dto.*;
 import com.insightflow.model.User;
@@ -9,6 +10,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Service @RequiredArgsConstructor
 public class AuthService {
     private final UserRepository userRepository;
@@ -17,22 +21,39 @@ public class AuthService {
 
     public AuthResponse register(RegisterRequest request) {
         if (userRepository.existsByEmail(request.getEmail()))
-            throw new RuntimeException("Email already registered");
+            throw AppException.conflict("Email already registered");
         User user = User.builder().name(request.getName()).email(request.getEmail())
                 .password(passwordEncoder.encode(request.getPassword())).role(Role.USER).build();
         userRepository.save(user);
-        String token = jwtService.generateToken(user.getEmail(), user.getRole().name());
+        String token = jwtService.generateToken(user.getId(), user.getEmail(), user.getRole().name());
         return AuthResponse.builder().token(token).email(user.getEmail())
                 .name(user.getName()).role(user.getRole().name()).build();
     }
 
     public AuthResponse login(AuthRequest request) {
         User user = userRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new RuntimeException("Invalid credentials"));
+                .orElseThrow(() -> AppException.unauthorized("Invalid credentials"));
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword()))
-            throw new RuntimeException("Invalid credentials");
-        String token = jwtService.generateToken(user.getEmail(), user.getRole().name());
+            throw AppException.unauthorized("Invalid credentials");
+        String token = jwtService.generateToken(user.getId(), user.getEmail(), user.getRole().name());
         return AuthResponse.builder().token(token).email(user.getEmail())
                 .name(user.getName()).role(user.getRole().name()).build();
+    }
+
+    // Get all users
+    public List<User> getAllUsers() {
+//        String password00 = passwordEncoder.encode("password123");
+//        String password01 = passwordEncoder.encode("password123");
+//        String password02 = passwordEncoder.encode("password123");
+//        List<User> users = new ArrayList<>();
+//        // For demonstration, we will create some dummy users if the database is empty
+//        users.add(User.builder().name("Alice").email("alice@example.com")
+//                .password(password00).role(Role.USER).build());
+//        users.add(User.builder().name("Bob").email("bob@example.com")
+//                .password(password01).role(Role.USER).build());
+//        users.add(User.builder().name("Charlie").email("charlie@example.com")
+//                .password(password02).role(Role.USER).build());
+//        return users;
+        return userRepository.findAll();
     }
 }

--- a/Phase1-Group-Projects/6-InsightFlow/backend/src/main/java/com/insightflow/service/DataSourceService.java
+++ b/Phase1-Group-Projects/6-InsightFlow/backend/src/main/java/com/insightflow/service/DataSourceService.java
@@ -1,9 +1,11 @@
 package com.insightflow.service;
 
 import com.insightflow.dto.*;
+import com.insightflow.exception.AppException;
 import com.insightflow.model.*;
 import com.insightflow.model.enums.DataSourceType;
 import com.insightflow.repository.DataSourceRepository;
+import com.insightflow.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import java.util.List;
@@ -11,19 +13,26 @@ import java.util.List;
 @Service @RequiredArgsConstructor
 public class DataSourceService {
     private final DataSourceRepository dataSourceRepository;
+    private final UserRepository userRepository;
 
     public List<DataSourceResponse> getAll() {
         return dataSourceRepository.findAllByOrderByCreatedAtDesc().stream()
                 .map(this::toResponse).toList();
     }
 
-    public DataSourceResponse create(DataSourceRequest request, User user) {
+    public DataSourceResponse create(DataSourceRequest request, UserPrincipal principal) {
+        DataSourceType type;
+        try {
+            type = DataSourceType.valueOf(request.getType());
+        } catch (IllegalArgumentException e) {
+            throw AppException.badRequest("Invalid data source type: " + request.getType());
+        }
         DataSource ds = DataSource.builder()
                 .name(request.getName())
                 .description(request.getDescription())
-                .type(DataSourceType.valueOf(request.getType()))
+                .type(type)
                 .connectionUrl(request.getConnectionUrl())
-                .createdBy(user)
+                .createdBy(userRepository.getReferenceById(principal.id()))
                 .build();
         return toResponse(dataSourceRepository.save(ds));
     }

--- a/Phase1-Group-Projects/6-InsightFlow/backend/src/main/java/com/insightflow/service/PipelineService.java
+++ b/Phase1-Group-Projects/6-InsightFlow/backend/src/main/java/com/insightflow/service/PipelineService.java
@@ -1,6 +1,7 @@
 package com.insightflow.service;
 
 import com.insightflow.dto.*;
+import com.insightflow.exception.AppException;
 import com.insightflow.model.*;
 import com.insightflow.model.enums.PipelineStatus;
 import com.insightflow.repository.*;
@@ -13,20 +14,21 @@ import java.util.List;
 public class PipelineService {
     private final PipelineRepository pipelineRepository;
     private final DataSourceRepository dataSourceRepository;
+    private final UserRepository userRepository;
 
     public List<PipelineResponse> getAll() {
         return pipelineRepository.findAllByOrderByCreatedAtDesc().stream()
                 .map(this::toResponse).toList();
     }
 
-    public PipelineResponse create(PipelineRequest request, User user) {
+    public PipelineResponse create(PipelineRequest request, UserPrincipal principal) {
         DataSource ds = dataSourceRepository.findById(request.getDataSourceId())
-                .orElseThrow(() -> new RuntimeException("Data source not found"));
+                .orElseThrow(() -> AppException.notFound("Data source not found"));
         Pipeline pipeline = Pipeline.builder()
                 .name(request.getName())
                 .description(request.getDescription())
                 .dataSource(ds)
-                .createdBy(user)
+                .createdBy(userRepository.getReferenceById(principal.id()))
                 .status(PipelineStatus.PENDING)
                 .build();
         return toResponse(pipelineRepository.save(pipeline));
@@ -34,13 +36,12 @@ public class PipelineService {
 
     public PipelineResponse runPipeline(Long id) {
         Pipeline pipeline = pipelineRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Pipeline not found"));
+                .orElseThrow(() -> AppException.notFound("Pipeline not found"));
         pipeline.setStatus(PipelineStatus.RUNNING);
         pipeline.setStartedAt(LocalDateTime.now());
         pipelineRepository.save(pipeline);
 
         // TODO: Actual pipeline execution logic
-        // For now, simulate completion
         pipeline.setStatus(PipelineStatus.COMPLETED);
         pipeline.setCompletedAt(LocalDateTime.now());
         pipeline.setRecordsProcessed(0L);

--- a/Phase1-Group-Projects/6-InsightFlow/frontend/utils/backend_auth.py
+++ b/Phase1-Group-Projects/6-InsightFlow/frontend/utils/backend_auth.py
@@ -7,7 +7,11 @@ Endpoints used:
   POST /api/auth/login     – AuthRequest  { email, password }
   POST /api/auth/register  – RegisterRequest { name, email, password }
 
-Both return AuthResponse { token, email, name, role }.
+Both return ApiResponse<AuthResponse>:
+  { status, message, data: { token, email, name, role } }
+
+The login() and register() functions unwrap and return the inner
+AuthResponse dict so callers don't need to know about the wrapper.
 """
 
 import os
@@ -24,7 +28,7 @@ def login(email: str, password: str) -> dict:
     """
     Authenticate against the Spring Boot backend.
 
-    Returns the AuthResponse dict on success.
+    Returns the inner AuthResponse dict { token, email, name, role } on success.
     Raises ValueError (bad credentials / server error) or
            ConnectionError (backend not reachable).
     """
@@ -41,9 +45,9 @@ def login(email: str, password: str) -> dict:
         )
 
     if resp.status_code == 200:
-        return resp.json()
+        return resp.json()["data"]  # unwrap ApiResponse → AuthResponse
 
-    # Surface the error message from the backend
+    # Surface the error message from the ApiResponse wrapper
     try:
         msg = resp.json()
         detail = msg if isinstance(msg, str) else (msg.get("message") or msg.get("error") or str(msg))
@@ -56,7 +60,7 @@ def register(name: str, email: str, password: str) -> dict:
     """
     Register a new user via the Spring Boot backend.
 
-    Returns the AuthResponse dict (includes JWT) on success.
+    Returns the inner AuthResponse dict { token, email, name, role } on success.
     Raises ValueError or ConnectionError on failure.
     """
     try:
@@ -72,7 +76,7 @@ def register(name: str, email: str, password: str) -> dict:
         )
 
     if resp.status_code == 200:
-        return resp.json()
+        return resp.json()["data"]  # unwrap ApiResponse → AuthResponse
 
     try:
         msg = resp.json()


### PR DESCRIPTION
This PR introduces a standardized communication layer between the backend and frontend, implements robust global exception handling, and optimizes authentication by eliminating redundant database hits during the JWT validation lifecycle.

### 🛠️ What Was Implemented

#### 1. Unified Response Structure (`dto/ApiResponse.java`)

Standardized all endpoint responses to follow a consistent JSON envelope. This ensures the frontend can predictably parse status and data.

* **Structure:** `{ "status": "success|error", "message": "...", "data": {...} }`
* **Helpers:** Includes static factory methods: `success(msg, data)`, `success(data)`, and `error(msg)`.

#### 2. Centralized Error Handling

Moved away from raw `RuntimeException` usage to a structured, status-aware approach.

* **`AppException.java`**: Custom exception class carrying `HttpStatus`. Includes semantic helpers like `.notFound()`, `.conflict()`, and `.unauthorized()`.
* **`GlobalExceptionHandler.java`**: Intercepts `AppException`, Validation errors (`MethodArgumentNotValidException`), and generic server errors to return the standard `ApiResponse` shape.

#### 3. Automated Monitoring (`aspect/LoggingAspect.java`)

Implemented AOP (Aspect-Oriented Programming) to decouple logging logic from business logic.

* **Controllers**: Logs every request/response with execution time at `INFO` level.
* **Services**: Tracks performance at `DEBUG` level.
* **Exceptions**: Automatically captures and logs errors with timing data.

#### 4. Performance: JWT Auth Optimization

Refactored `JwtAuthFilter` to remove the `UserRepository` dependency, significantly reducing database latency on authenticated requests.

* **Stateless Auth**: Roles and User IDs are now extracted directly from JWT claims.
* **Lightweight Principal**: Replaced the full `User` entity in the Security Context with a `UserPrincipal` record.
* **JPA Optimization**: Controllers now use `@AuthenticationPrincipal UserPrincipal`. For foreign key assignments, services use `getReferenceById()` to obtain a JPA proxy, avoiding unnecessary eager database fetches.

---

### ⚠️ Frontend Breaking Changes

> [!IMPORTANT]
> The **Frontend Authentication logic** has been modified to accommodate the new `ApiResponse` structure. Ensure the client-side interceptors or services are updated to access data via the `.data` property of the response object rather than the root level.